### PR TITLE
goaccess visitors chart: change to time on x-axis

### DIFF
--- a/util/server/run_goaccess
+++ b/util/server/run_goaccess
@@ -10,6 +10,5 @@ goaccess /var/log/caddy/access.log \
   --ignore-crawlers \
   --all-static-files \
   --log-format=CADDY \
-  --sort-panel=VISITORS,BY_HITS,DESC \
   --sort-panel=REQUESTS,BY_VISITORS,DESC
   


### PR DESCRIPTION
instead of sort by hits descending for the visitors chart, can we show time on x-axis instead to see can see trends/upticks over time?